### PR TITLE
caching enhancements for codegen pipeline

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,8 @@ require (
 	github.com/crossplane-contrib/terraform-provider-gen v0.0.0-20210317192616-e9255f2c6e7d
 	github.com/hashicorp/terraform v0.13.5
 	github.com/hashicorp/terraform-svchost v0.0.0-20191011084731-65d371908596
+	github.com/pkg/errors v0.9.1
+	github.com/spf13/afero v1.4.1
 	k8s.io/api v0.18.8
 	k8s.io/apimachinery v0.18.8
 )

--- a/go.sum
+++ b/go.sum
@@ -735,6 +735,7 @@ github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasO
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.2.2 h1:5jhuqJyZCZf2JRofRvN/nIFgIWNzPa3/Vz8mYylgbWc=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
+github.com/spf13/afero v1.4.1 h1:asw9sl74539yqavKaglDM5hFpdJVK0Y5Dr/JOgQ89nQ=
 github.com/spf13/afero v1.4.1/go.mod h1:Ai8FlHk4v/PARR026UzYexafAt9roJ7LcLMAmO6Z93I=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=

--- a/internal/tfbin/cache.go
+++ b/internal/tfbin/cache.go
@@ -1,0 +1,119 @@
+package tfbin
+
+import (
+	"github.com/pkg/errors"
+	"github.com/spf13/afero"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+type Cache struct {
+	fs   afero.Fs
+	base string
+}
+
+const DefaultCacheDirName string = ".tf-cache"
+
+// NewDefaultCache returns a cache with basePath
+// set to $CWD/.tf-cache
+func NewDefaultCache(afs afero.Fs) (*Cache, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+	return NewCache(afs, path.Join(cwd, DefaultCacheDirName))
+}
+
+func NewCache(afs afero.Fs, basePath string) (*Cache, error) {
+	abs, err := filepath.Abs(basePath)
+	if err != nil {
+		return nil, err
+	}
+	exists, err := afero.DirExists(afs, abs)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		err = afs.MkdirAll(abs, os.ModePerm)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &Cache{fs: afs, base: basePath}, nil
+}
+
+func (c *Cache) ProviderMetaWriter(pm ProviderMeta, filename string) (io.WriteCloser, error) {
+	dir := path.Join(c.base, pm.Host, pm.Namespace, pm.Name, pm.Version, pm.OS, pm.Arch)
+	err := c.fs.MkdirAll(dir, os.ModePerm)
+	if err != nil {
+		return nil, err
+	}
+	writePath := path.Join(dir, filename)
+	return c.fs.Create(writePath)
+}
+
+func (c *Cache) ProviderMetaReader(pm ProviderMeta) (io.ReadCloser, string, error) {
+	dir := path.Join(c.base, pm.Host, pm.Namespace, pm.Name, pm.Version, pm.OS, pm.Arch)
+	files, err := afero.ReadDir(c.fs, dir)
+	if err != nil {
+		return nil, "", err
+	}
+	if len(files) > 1 {
+		return nil, "", errors.New("Unexpected duplicate files in cache at %s" + dir)
+	}
+	f := files[0]
+	fh, err := c.fs.Open(path.Join(dir, f.Name()))
+	return fh, f.Name(), err
+}
+
+func (c *Cache) Search(query ProviderMeta) (ProviderMeta, error) {
+	f := &optionFinder{base: c.base, found: make([]ProviderMeta, 0)}
+	err := afero.Walk(c.fs, c.base, f.Walk)
+	if err != nil {
+		return ProviderMeta{}, err
+	}
+	return query.FindMatch(f.found)
+}
+
+type optionFinder struct {
+	base  string
+	found []ProviderMeta
+}
+
+const (
+	hostPosition      int = 0
+	namespacePosition int = 1
+	namePosition      int = 2
+	versionPosition   int = 3
+	osPosition        int = 4
+	archPosition      int = 5
+)
+
+func (f *optionFinder) Walk(path string, info os.FileInfo, err error) error {
+	if info.IsDir() {
+		return nil
+	}
+	dir, _ := filepath.Split(path)
+	rel, err := filepath.Rel(f.base, dir)
+	if err != nil {
+		return err
+	}
+
+	dirs := strings.Split(rel, string(os.PathSeparator))
+	if len(dirs) == 5 {
+		dirs = append([]string{""}, dirs...)
+	}
+	pm := ProviderMeta{
+		Host:      dirs[hostPosition],
+		Namespace: dirs[namespacePosition],
+		Name:      dirs[namePosition],
+		Version:   dirs[versionPosition],
+		OS:        dirs[osPosition],
+		Arch:      dirs[archPosition],
+	}
+	f.found = append(f.found, pm)
+	return nil
+}

--- a/internal/tfbin/providermeta.go
+++ b/internal/tfbin/providermeta.go
@@ -1,0 +1,56 @@
+package tfbin
+
+import "fmt"
+
+type ProviderMeta struct {
+	Host      string
+	Namespace string
+	Name      string
+	OS        string
+	Arch      string
+	Version   string
+}
+
+func (poa ProviderMeta) Equals(p2 ProviderMeta) bool {
+	if poa.Arch != p2.Arch {
+		return false
+	}
+	if poa.OS != p2.OS {
+		return false
+	}
+	if poa.Name != p2.Name {
+		return false
+	}
+	if poa.Namespace != p2.Namespace {
+		return false
+	}
+	if poa.Host != p2.Host {
+		return false
+	}
+	if poa.Version != p2.Version {
+		return false
+	}
+	return true
+}
+
+func (pm ProviderMeta) FindMatch(options []ProviderMeta) (ProviderMeta, error) {
+	for _, opt := range options {
+		if opt.Equals(pm) {
+			return opt, nil
+		}
+	}
+	return ProviderMeta{}, &NoMatchError{ProviderMeta: pm}
+}
+
+func (pm ProviderMeta) String() string {
+	return fmt.Sprintf("host=%s, namespace=%s, name=%s, os=%s, arch=%s, version=%s",
+		pm.Host, pm.Namespace, pm.Name, pm.OS, pm.Arch, pm.Version)
+}
+
+type NoMatchError struct {
+	ProviderMeta ProviderMeta
+}
+
+func (e *NoMatchError) Error() string {
+	return "No results for query: " + e.ProviderMeta.String()
+}

--- a/internal/tfbin/providermeta_test.go
+++ b/internal/tfbin/providermeta_test.go
@@ -1,0 +1,89 @@
+package tfbin
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/Masterminds/semver"
+)
+
+func TestChooserPicksHighest(t *testing.T) {
+	p := ProviderMeta{
+		Name:      "test",
+		Namespace: "upbound",
+		OS:        "TempleOS",
+		Arch:      "cthulu64",
+		Host:      "localhost",
+	}
+	version := "1.23.4"
+	expected := newTestPM(p.Host, p.Namespace, version, p.Name, p.OS, p.Arch)
+	options := []ProviderMeta{
+		newTestPM(p.Host, p.Namespace, "1.21.0", p.Name, p.OS, p.Arch),
+		newTestPM(p.Host, p.Namespace, "1.22.0", p.Name, p.OS, p.Arch),
+		newTestPM(p.Host, p.Namespace, "1.23.0", p.Name, p.OS, p.Arch),
+		expected,
+		newTestPM(p.Host, p.Namespace, "1.23.4", "nope", p.OS, p.Arch),
+		newTestPM(p.Host, p.Namespace, "1.23.4", p.Name, "nopeOs", p.Arch),
+		newTestPM(p.Host, p.Namespace, "1.23.4", p.Name, p.OS, "noThulu64"),
+		newTestPM(p.Host, p.Namespace, "1.24.0", p.Name, p.OS, p.Arch),
+	}
+	err := checkExpected(expected, options)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestChooserNoMatch(t *testing.T) {
+	p := ProviderMeta{
+		Name:      "test",
+		Namespace: "upbound",
+		OS:        "TempleOS",
+		Arch:      "cthulu64",
+		Host:      "localhost",
+	}
+	version := "1.23.4"
+	expected := newTestPM(p.Host, p.Namespace, version, p.Name, p.OS, p.Arch)
+	options := []ProviderMeta{
+		newTestPM(p.Host, p.Namespace, "1.23.4", "nope", p.OS, p.Arch),
+		newTestPM(p.Host, p.Namespace, "1.23.4", p.Name, "nopeOs", p.Arch),
+		newTestPM(p.Host, p.Namespace, "1.23.4", p.Name, p.OS, "noThulu64"),
+	}
+	err := checkExpected(expected, options)
+	if err == nil {
+		t.Errorf("Got a matching option where no valid options were provided")
+	}
+}
+
+func checkExpected(expected ProviderMeta, options []ProviderMeta) error {
+	observed, err := expected.FindMatch(options)
+	if err != nil {
+		return fmt.Errorf("Unexpected error from ProviderQuery.TopRanked = %s", err)
+	}
+
+	if !expected.Equals(observed) {
+		return fmt.Errorf("FindMatch chose an unexpected ProviderMeta. Expected=%s, Actual=%s", expected, observed)
+	}
+	return nil
+}
+
+type testOption struct {
+	host          string
+	versionString string
+	namespace     string
+	name          string
+	os            string
+	arch          string
+}
+
+func (to *testOption) Version() *semver.Version {
+	v, _ := semver.NewVersion(to.versionString)
+	return v
+}
+
+func (to *testOption) ProviderMeta() ProviderMeta {
+	return ProviderMeta{Name: to.name, Namespace: to.namespace, OS: to.os, Arch: to.arch}
+}
+
+func newTestPM(host, namespace, version, provider, os, arch string) ProviderMeta {
+	return ProviderMeta{Host: host, Version: version, Namespace: namespace, Name: provider, OS: os, Arch: arch}
+}

--- a/internal/tfbin/registry.go
+++ b/internal/tfbin/registry.go
@@ -1,0 +1,131 @@
+package tfbin
+
+import (
+	"archive/zip"
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/hashicorp/terraform/registry"
+	"github.com/hashicorp/terraform/registry/regsrc"
+	"github.com/pkg/errors"
+)
+
+type TerraformRegistry struct {
+	client *registry.Client
+	cache  *Cache
+}
+
+func (tr *TerraformRegistry) tfProvider(target ProviderMeta) *regsrc.TerraformProvider {
+	return regsrc.NewTerraformProvider(target.Name, target.OS, target.Arch)
+}
+
+func (tr *TerraformRegistry) Search(query ProviderMeta) (ProviderMeta, error) {
+	var err error
+	if tr.cache != nil {
+		cachedResult, err := tr.cache.Search(query)
+		if err == nil {
+			return cachedResult, nil
+		} else {
+			// fall through to the registry search if not found in cache
+			// but barf if there is something actually wrong with the cache
+			var e *NoMatchError
+			if !errors.As(err, &e) {
+				return ProviderMeta{}, err
+			}
+		}
+	}
+
+	resp, err := tr.client.TerraformProviderVersions(tr.tfProvider(query))
+	if err != nil {
+		return ProviderMeta{}, err
+	}
+
+	opts := make([]ProviderMeta, 0)
+	for _, tpv := range resp.Versions {
+		for _, p := range tpv.Platforms {
+			pm := ProviderMeta{
+				Host:      query.Host,
+				Namespace: query.Namespace,
+				Name:      query.Name,
+				OS:        p.OS,
+				Arch:      p.Arch,
+				Version:   tpv.Version,
+			}
+			opts = append(opts, pm)
+		}
+	}
+	return query.FindMatch(opts)
+}
+
+func (tr *TerraformRegistry) ProviderMetaReader(pm ProviderMeta) (io.ReadCloser, string, error) {
+	if tr.cache != nil {
+		rc, fname, err := tr.cache.ProviderMetaReader(pm)
+		if err == nil {
+			return rc, fname, err
+		} else {
+
+		}
+	}
+	loc, err := tr.client.TerraformProviderLocation(tr.tfProvider(pm), pm.Version)
+	if err != nil {
+		return nil, "", err
+	}
+	zipURL := loc.DownloadURL // retrieving the actual zip
+	resp, err := http.Get(zipURL)
+	if err != nil {
+		return nil, "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return nil, "", fmt.Errorf("GET of %s had a non-200 result: %d", zipURL, resp.StatusCode)
+	}
+
+	// unpack the zip onto the local filesystem
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, "", fmt.Errorf("Error reading body from request to %s: %v", zipURL, err)
+	}
+	zread, err := zip.NewReader(bytes.NewReader(body), int64(len(body)))
+	if len(zread.File) > 1 {
+		return nil, "", fmt.Errorf("Provider zip archive unexpectedly contains multiple files, unsure which is the provider. Zip URL=%s", zipURL)
+	}
+	zfh := zread.File[0]
+	fh, err := zfh.Open()
+	if err != nil {
+		return nil, "", err
+	}
+	if tr.cache == nil {
+		return fh, zfh.Name, nil
+	}
+	defer fh.Close()
+	wc, err := tr.cache.ProviderMetaWriter(pm, zfh.Name)
+	if err != nil {
+		return nil, "", errors.Wrap(err, "Error initializing local cache to store provider binary.")
+	}
+	defer wc.Close()
+	_, err = io.Copy(wc, fh)
+	if err != nil {
+		return nil, "", errors.Wrap(err, "Error writing provider binary from registry to local cache.")
+	}
+	return tr.cache.ProviderMetaReader(pm)
+}
+
+type TerraformRegistryOption func(terraformRegistry *TerraformRegistry)
+
+func NewTerraformRegistry(options ...TerraformRegistryOption) *TerraformRegistry {
+	client := registry.NewClient(nil, nil)
+	tr := &TerraformRegistry{client: client}
+	for _, o := range options {
+		o(tr)
+	}
+	return tr
+}
+
+func WithCache(c *Cache) TerraformRegistryOption {
+	return func(tr *TerraformRegistry) {
+		tr.cache = c
+	}
+}

--- a/main.go
+++ b/main.go
@@ -1,39 +1,33 @@
 package main
 
 import (
-	"archive/zip"
-	"bytes"
 	"fmt"
+	"github.com/crossplane-contrib/terraform-provider-dl/internal/tfbin"
+	"github.com/spf13/afero"
 	"io"
-	"io/ioutil"
-	"net/http"
 	"os"
 	"path"
 	"path/filepath"
 	"runtime"
-	"sort"
 	"strings"
 
-	"github.com/Masterminds/semver"
 	"github.com/alecthomas/kong"
 	"github.com/crossplane-contrib/terraform-provider-gen/pkg/provider"
-	"github.com/hashicorp/terraform/registry"
-	"github.com/hashicorp/terraform/registry/regsrc"
-	"github.com/hashicorp/terraform/registry/response"
 )
 
 var CLI struct {
 	ProviderName string `help:"Official Terraform provider name; the name that would be used in a tf provider block."`
-	Version string `help:"Semantic version constraint for the desired provider. See github.com/Masterminds/semver for syntax"`
-	OS string `help:"Target operating system for provider binary."`
-	Arch string `help:"Target system architecture for provider binary."`
-	Output string `help:"The binary will be written to a subdirectory ensuring unique provider+version+arch within the --output location."`
-	Config string `help:"Path to a terraform-provider-gen config file."`
+	Version      string `help:"Semantic version constraint for the desired provider. See github.com/Masterminds/semver for syntax"`
+	OS           string `help:"Target operating system for provider binary."`
+	Arch         string `help:"Target system architecture for provider binary."`
+	Output       string `help:"The binary will be written to a subdirectory ensuring unique provider+version+arch within the --output location."`
+	Config       string `help:"Path to a terraform-provider-gen config file."`
 }
 
 func main() {
+	var err error
 	ctx := kong.Parse(&CLI)
-	// arg defaults
+
 	if CLI.Config != "" {
 		cfg, err := provider.ConfigFromFile(CLI.Config)
 		if err != nil {
@@ -42,13 +36,7 @@ func main() {
 		CLI.ProviderName = cfg.Name
 		CLI.Version = cfg.ProviderVersion
 	}
-	if len(strings.Split(CLI.ProviderName, "/")) < 2 {
-		CLI.ProviderName = "hashicorp/" + CLI.ProviderName
-	}
-	vc, err := semver.NewConstraint(CLI.Version)
-	if err != nil {
-		ctx.FatalIfErrorf(err)
-	}
+
 	if CLI.OS == "" {
 		CLI.OS = runtime.GOOS
 	}
@@ -56,125 +44,66 @@ func main() {
 		CLI.Arch = runtime.GOARCH
 	}
 
-	// provider simply holds metadata about the provider we want to search the registry for
-	provider := regsrc.NewTerraformProvider(CLI.ProviderName, CLI.OS, CLI.Arch)
-	client := registry.NewClient(nil, nil)
-
-	// will fail if we can't find a version in the registry that matches the version constraint + arch + os
-	v, err := BestVersion(client, provider, vc)
-	if err != nil {
-		ctx.FatalIfErrorf(err)
+	pm := tfbin.ProviderMeta{
+		OS:      CLI.OS,
+		Arch:    CLI.Arch,
+		Version: CLI.Version,
+	}
+	nameParts := strings.Split(CLI.ProviderName, "/")
+	switch len(nameParts) {
+	case 1:
+		pm.Namespace = "hashicorp"
+		pm.Name = CLI.ProviderName
+	case 2:
+		pm.Name, pm.Namespace = nameParts[0], nameParts[1]
+	default:
+		ctx.FatalIfErrorf(fmt.Errorf("Expecting only one slash in provider name -- namespace/name. got: %s", CLI.ProviderName))
 	}
 
-	if CLI.Output != "" {
-		CLI.Output, err = filepath.Abs(CLI.Output)
+	if CLI.Output == "" {
+		CLI.Output, err = os.Getwd()
 		if err != nil {
 			ctx.FatalIfErrorf(err)
 		}
-	} else {
-		// we found a suitable match, so set up local path to save the provider binary
-		dir, err := os.Getwd()
+	}
+	CLI.Output, err = filepath.Abs(CLI.Output)
+	if err != nil {
+		ctx.FatalIfErrorf(err)
+	}
+
+	afs := afero.NewOsFs()
+	exists, err := afero.DirExists(afs, CLI.Output)
+	if err != nil {
+		ctx.FatalIfErrorf(err)
+	}
+	if !exists {
+		err = afs.MkdirAll(CLI.Output, os.ModePerm)
 		if err != nil {
 			ctx.FatalIfErrorf(err)
 		}
-		osArch := fmt.Sprintf("%s_%s", provider.OS, provider.Arch)
-		CLI.Output = path.Join(dir, "tf-plugin", provider.RawHost.String(), provider.RawNamespace, provider.RawName, v, osArch)
 	}
-	err = os.MkdirAll(CLI.Output, os.ModePerm)
+
+	cache, err := tfbin.NewDefaultCache(afs)
+	reg := tfbin.NewTerraformRegistry(tfbin.WithCache(cache))
+	match, err := reg.Search(pm)
 	if err != nil {
 		ctx.FatalIfErrorf(err)
 	}
 
-	// specific registry entry for this provider/version/arch/os, result contains final zip download url
-	zipURL, err := VersionZipURL(client, provider, v)
+	reader, filename, err := reg.ProviderMetaReader(match)
 	if err != nil {
 		ctx.FatalIfErrorf(err)
 	}
+	defer reader.Close()
 
-	// retrieving the actual zip
-	resp, err := http.Get(zipURL)
+	writePath := path.Join(CLI.Output, filename)
+	writer, err := afs.Create(writePath)
 	if err != nil {
 		ctx.FatalIfErrorf(err)
 	}
-	defer resp.Body.Close()
-	if resp.StatusCode != 200 {
-		ctx.FatalIfErrorf(fmt.Errorf("GET of %s had a non-200 result: %d", zipURL, resp.StatusCode))
-	}
-
-	// unpack the zip onto the local filesystem
-	body, err := ioutil.ReadAll(resp.Body)
+	defer writer.Close()
+	_, err = io.Copy(writer, reader)
 	if err != nil {
-		ctx.FatalIfErrorf(fmt.Errorf("Error reading body from request to %s: %v", zipURL, err))
+		ctx.FatalIfErrorf(err)
 	}
-	zread, err := zip.NewReader(bytes.NewReader(body), int64(len(body)))
-	for _, zfh := range zread.File {
-		localPath := path.Join(CLI.Output, zfh.Name)
-		fh, err := os.Create(localPath)
-		if err != nil {
-			ctx.FatalIfErrorf(fmt.Errorf("Failed to create local filehandle at %s to save filename '%s' from %s, with err=%v", localPath, zfh.Name, zipURL, err))
-		}
-		zfhReader, err := zfh.Open()
-		if err != nil {
-			ctx.FatalIfErrorf(fmt.Errorf("Error reading filename %s from zip retrieved from %s, with err=%v", zfh.Name, zipURL, err))
-		}
-		defer fh.Close()
-		defer zfhReader.Close()
-		_, err = io.Copy(fh, zfhReader)
-		if err != nil {
-			ctx.FatalIfErrorf(fmt.Errorf("Error copying between zip archive file %s to local file %s from zip retrieved from %s, with err=%v", zfh.Name, localPath, zipURL, err))
-		}
-
-		fmt.Printf("\nWrote provider plugin to local path %s\nWhere terraform-provider-gen or a terraform-provider-runtime based provider require a plugin path argument or environment variable, use the path of the directory containing the binary, ie:\n%s\n", localPath, CLI.Output)
-	}
-}
-
-func VersionZipURL(client *registry.Client, provider *regsrc.TerraformProvider, version string) (string, error) {
-	loc, err := client.TerraformProviderLocation(provider, version)
-	if err != nil {
-		return "", err
-	}
-	return loc.DownloadURL, nil
-}
-
-func BestVersion(client *registry.Client, provider *regsrc.TerraformProvider, vc *semver.Constraints) (string, error) {
-	resp, err := client.TerraformProviderVersions(provider)
-	if err != nil {
-		return "", err
-	}
-	vmap := mapForPlatform(resp, provider.OS, provider.Arch)
-	smvs := make([]*semver.Version, 0)
-	for sv, _ := range vmap {
-		v, err := semver.NewVersion(sv)
-		if err != nil {
-			return "", err
-		}
-		smvs = append(smvs, v)
-	}
-	sort.Sort(semver.Collection(smvs))
-	for i := len(smvs); i > 0; i-- {
-		candidate := smvs[i-1]
-		if vc.Check(candidate) {
-			return candidate.String(), nil
-		}
-	}
-	return "", fmt.Errorf("Could not find a suitable match for the specified combination of provider, os, arch and version")
-}
-
-func mapForPlatform(vr *response.TerraformProviderVersions, os, arch string) map[string]*response.TerraformProviderVersion {
-	m := make(map[string]*response.TerraformProviderVersion)
-	for _, v := range vr.Versions {
-		if platformSupported(v, os, arch) {
-			m[v.Version] = v
-		}
-	}
-	return m
-}
-
-func platformSupported(version *response.TerraformProviderVersion, os, arch string) bool {
-	for _, p := range version.Platforms {
-		if p.OS == os && p.Arch == arch {
-			return true
-		}
-	}
-	return false
 }


### PR DESCRIPTION
The codegen pipeline needs to be able to download to a specific location in order to simplify the construction of the `--pluginPath` flag. But dropping the plugin into a custom named directory doesn't preserve enough info to determine if the current file in the directory is the right build for the provider+os+arch+version. So a separate cache directory is used, which preserves provider metadata in nested directory naming, so that every time the download command is run, we can simply copy the correct version of the plugin from the cache directory (or read through to the terraform registry if it isn't present).