### PR TITLE
Fix provider namespace used in queries and fix processing of the provider zip archive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/crossplane-contrib/terraform-provider-dl
+module github.com/ulucinar/terraform-provider-dl
 
 go 1.14
 

--- a/main.go
+++ b/main.go
@@ -2,14 +2,16 @@ package main
 
 import (
 	"fmt"
-	"github.com/crossplane-contrib/terraform-provider-dl/internal/tfbin"
-	"github.com/spf13/afero"
 	"io"
 	"os"
 	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
+
+	"github.com/spf13/afero"
+
+	"github.com/ulucinar/terraform-provider-dl/internal/tfbin"
 
 	"github.com/alecthomas/kong"
 	"github.com/crossplane-contrib/terraform-provider-gen/pkg/provider"


### PR DESCRIPTION
This PR proposes a fix for the query sent to Terraform registry. Currently, the query does not properly incorporate the namespace of the provider and fails to download a provider plugin binary if the provider is not in the default `hashicorp` namespace.

This PR also addresses an issue during processing of the provider zip archive. My observation is that certain provider archives  can contain extra files in addition to the plugin binary.

For some broader context of this PR, please see:
https://github.com/upbound/purple-squad/pull/621#issuecomment-895894238

Because I'm using this branch right now for building Terraform provider shared RPC services, the module is under my GitHub organization. Just before merging, I will revert the module path change, so please ignore it.